### PR TITLE
when create tasks, assign them to creator as owner

### DIFF
--- a/EmailHandler.php
+++ b/EmailHandler.php
@@ -69,6 +69,7 @@ class EmailHandler extends Base implements ClientInterface
             'title' => $this->getTitle($payload),
             'description' => trim($this->getDescription($payload)),
             'creator_id' => $user['id'],
+			'owner_id' => $user['id'], // Based on the idea that tasks cannot be orphans, assign it to the creator
             'swimlane_id' => $this->getSwimlaneId($project),
         ));
 


### PR DESCRIPTION
When a task is created via email, is not assigned (owner) to anyone so it's an orphan.
Based on the idea that each task should be managed, we use in our company the "auto-assign to self" unless then re-assigned to someone else during meeting.

Let me know your thoughts please.
Julien